### PR TITLE
Use type StarlightIcon instead of ComponentProps

### DIFF
--- a/.changeset/few-trains-approve.md
+++ b/.changeset/few-trains-approve.md
@@ -1,0 +1,5 @@
+---
+'starlight-sidebar-topics': patch
+---
+
+Fixes a potential type issue for users manually running `tsc` in their projects.

--- a/packages/starlight-sidebar-topics/data.ts
+++ b/packages/starlight-sidebar-topics/data.ts
@@ -1,5 +1,4 @@
-import type { Icon } from '@astrojs/starlight/components'
-import type { ComponentProps } from 'astro/types'
+import type { StarlightIcon } from '@astrojs/starlight/types'
 
 import type { SidebarTopicBadge } from './libs/config'
 
@@ -22,7 +21,7 @@ export interface StarlightSidebarTopicsRouteData {
     /**
      * The name of an optional icon associated with the topic set to one of Starlight’s built-in icons.
      */
-    icon?: ComponentProps<typeof Icon>['name']
+    icon?: StarlightIcon
     /**
      * Indicates if the current page is part of the topic.
      */


### PR DESCRIPTION
Thank you so much for this plugin 💐. I'm trying to use it in my project because it does exactly what I need!

**Describe the pull request**

I'm removing the usage of `ComponentProps` and the Starlight `Icon` component to reference the type of the icon name in favor of a dedicated type `StarlightIcon` for icon names that Starlight exports: https://starlight.astro.build/reference/icons/#starlighticon-type

**Why**

My project uses `tsc --noEmit` (in addition to `astro check`) to verify that there are no type errors outside of Astro files. This makes it necessary to provide a module definition for `.astro` files so that Typescript knows how to interpret them when imported from `.ts` files. In my project this is only relevant in `.test.ts` files that I sometimes write to unit test my Astro components.

This is my module definition in `env.d.ts`:

```
declare module "*.astro" {
  import type { AstroComponentFactory } from "astro/runtime/server";
  const component: AstroComponentFactory;
  export default component;
}
```

It's not great. It doesn't provide any type safety, but at least it makes the project compile.

After I added this plugin to my project, I started getting this Typescript error:

```
node_modules/starlight-sidebar-topics/data.ts:25:40 - error TS2339: Property 'name' does not exist on type '{}'.

25     icon?: ComponentProps<typeof Icon>['name']
                                          ~~~~~~
```

It only shows up when running `tsc --noEmit`, not `astro check`. I don't fully understand how Typescript or Astro types work under the hood but I believe that it is technically not possible to have correct types for Astro components when importing them from `.ts` files.

I believe this problem will be fixed `data.ts` stops importing an Astro component, trying to read its type, and instead import a dedicated icon name type. I suspect the Astro team expected this problem and use-case to appear and that why they exported this type 🤔 

Thank you in advance for taking a look at this PR.
