### PR TITLE
remove double padding in topics.astro css

### DIFF
--- a/packages/starlight-sidebar-topics/components/Topics.astro
+++ b/packages/starlight-sidebar-topics/components/Topics.astro
@@ -74,7 +74,6 @@ const { topics } = Astro.locals.starlightSidebarTopics
     border: 1px solid var(--sl-color-gray-4);
     display: flex;
     justify-content: center;
-    padding: 0.1875rem;
     padding: 0.25rem;
   }
 


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

I'm not sure if one is supposed to be margin, but the padding is double declared in the same block. Since the last one takes precedence, I assume that one must be the right one. 

https://github.com/HiDeoo/starlight-sidebar-topics/blob/main/packages/starlight-sidebar-topics/components/Topics.astro
```css
/* ... */

  .starlight-sidebar-topics-icon {
    align-items: center;
    border-radius: 0.25rem;
    border: 1px solid var(--sl-color-gray-4);
    display: flex;
    justify-content: center;
    padding: 0.1875rem;
    padding: 0.25rem;
  }

/* ... */
```

**Why**

Optional, just may be confusing to some or an indication of an error. Hopefully this is not considered a frivolous PR.

**How**

Removed the top line which was being immediately redone by the next line.

<!-- Feel free to add additional comments. -->

\- 🦥
