### PR TITLE
fix: defensive handling for undefined pagination in Pagination.astro

### DIFF
--- a/overrides/Pagination.astro
+++ b/overrides/Pagination.astro
@@ -1,0 +1,23 @@
+---
+import Default from '@astrojs/starlight/components/Pagination.astro'
+import type { Props } from '@astrojs/starlight/props'
+
+import { isTopicFirstPage, isTopicLastPage } from '../libs/sidebar'
+
+const { pagination, sidebar, slug } = Astro.props
+let prev = undefined
+let next = undefined
+if (pagination) {
+  ({ prev, next } = pagination)
+}
+
+if (isTopicFirstPage(sidebar, slug)) {
+  prev = undefined
+}
+
+if (isTopicLastPage(sidebar, slug)) {
+  next = undefined
+}
+---
+
+<Default {...Astro.props} pagination={{ prev, next }}><slot /></Default>


### PR DESCRIPTION
Plugin PR draft: starlight-sidebar-topics — pagination guard + notes

Problem
-------
When integrating `starlight-sidebar-topics` into this project the build sometimes
failed with an error like:

  Cannot destructure property 'prev' of 'pagination' as it is undefined.

This happens when the Starlight `Sidebar`/`Pagination` overrides are used on pages
that do not provide a `pagination` prop (for example, topic landing pages).

Proposed fix
------------
Add a small defensive guard in `overrides/Pagination.astro` so the override
handles the case when `pagination` is undefined before destructuring `prev` and
`next`.

Patch summary
-------------
- Check `if (pagination)` before destructuring, or initialize `prev`/`next` to undefined and assign only if `pagination` exists.

Testing
-------
1. In this repo I applied the fix locally and ran `npm run build` — build succeeded.
2. I added sample pages and ensured topic landing pages without pagination no longer crash.

Suggested PR contents
---------------------
- The minimal code change in `overrides/Pagination.astro`.
- A brief test or note in README explaining the edge case.

Additional notes
----------------
I also adapted our site `astro.config.mjs` to generate plain slug lists for topics so
the plugin receives sidebar items that Starlight accepts. That is a repository-side
change and not part of the plugin PR; it's documented here for context.

If you'd like, I can prepare the git branch and the patch file ready for a PR, or
open the PR from this repository (I can prepare the branch and show the diff; remote push requires your GitHub credentials).
