### PR TITLE
feat: cascade layers

### DIFF
--- a/.changeset/forty-pans-talk.md
+++ b/.changeset/forty-pans-talk.md
@@ -1,0 +1,9 @@
+---
+'starlight-sidebar-topics': minor
+---
+
+Groups all of the Starlight Sidebar Topics CSS declarations into a single `sidebar-topics` [cascade layer](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Cascade_layers).
+
+This change aligns with the Starlight CSS architecture and allows for easier customization of the Starlight Sidebar Topics CSS as any custom unlayered CSS will override the default styles. If you are using cascade layers in your custom CSS, you can use the [`@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) CSS at-rule to define the order of precedence for different layers including the ones used by Starlight and the Starlight Rapide theme.
+
+Make sure to check your site’s sidebar appearance when upgrading to make sure there are no style regressions caused by this change.

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
               link: '/docs/getting-started/',
               icon: 'open-book',
               items: [
-                { label: 'Start Here', items: ['docs/getting-started', 'docs/configuration'] },
+                { label: 'Start Here', items: ['docs/getting-started', 'docs/configuration', 'docs/customization'] },
                 { label: 'Guides', autogenerate: { directory: 'docs/guides' } },
                 { label: 'Resources', items: [{ label: 'Plugins and Tools', slug: 'docs/resources/starlight' }] },
               ],

--- a/docs/src/content/docs/docs/customization.mdx
+++ b/docs/src/content/docs/docs/customization.mdx
@@ -1,0 +1,25 @@
+---
+title: Customization
+---
+
+## Custom CSS
+
+To customize the styles applied to your Starlight sidebar when using `starlight-sidebar-topics`, you can provide additional CSS files to modify or extend Starlight and `starlight-sidebar-topics` default styles.
+
+[Learn more about custom CSS in the Starlight documentation.](https://starlight.astro.build/guides/css-and-tailwind/#custom-css-styles)
+
+## Cascade layers
+
+Like Starlight, `starlight-sidebar-topics` uses [cascade layers](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Cascade_layers) internally to manage the order of its styles.
+This ensures a predictable CSS order and allows for simpler overrides.
+Any custom unlayered CSS will override the default styles from Starlight and `starlight-sidebar-topics`.
+
+If you are using cascade layers, you can use [`@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) in your [custom CSS](https://starlight.astro.build/guides/css-and-tailwind/#custom-css-styles) to define the order of precedence for different layers relative to styles from the `starlight` and `sidebar-topics` layers:
+
+```css "starlight" "sidebar-topics"
+/* src/styles/custom.css */
+@layer my-reset, starlight, sidebar-topics, my-overrides;
+```
+
+The example above defines a custom layer named `my-reset`, applied before all Starlight and `starlight-sidebar-topics` layers, and another named `my-overrides`, applied after all Starlight and `starlight-sidebar-topics` layers.
+Any styles in the `my-overrides` layer would take precedence over Starlight and `starlight-sidebar-topics` styles, but Starlight or `starlight-sidebar-topics` could still change styles set in the `my-reset` layer.

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -8,5 +8,5 @@
 
 /* TODO(trueberryless/HiDeoo): Remove example */
 .starlight-sidebar-topics-current .starlight-sidebar-topics-icon {
-    background: white;
+  background: white;
 }

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -5,3 +5,8 @@
   justify-content: center;
   line-height: var(--size);
 }
+
+/* TODO(trueberryless/HiDeoo): Remove example */
+.starlight-sidebar-topics-current .starlight-sidebar-topics-icon {
+    background: white;
+}

--- a/packages/starlight-sidebar-topics/components/Topics.astro
+++ b/packages/starlight-sidebar-topics/components/Topics.astro
@@ -27,63 +27,65 @@ const { topics } = Astro.locals.starlightSidebarTopics
 </ul>
 
 <style>
-  ul {
-    list-style: none;
-    padding: 0;
-  }
+  @layer sidebar-topics {
+    ul {
+      list-style: none;
+      padding: 0;
+    }
 
-  ul::after {
-    content: '';
-    display: block;
-    margin-top: 1rem;
-    height: 1px;
-    border-top: 1px solid var(--sl-color-hairline-light);
-  }
+    ul::after {
+      content: '';
+      display: block;
+      margin-top: 1rem;
+      height: 1px;
+      border-top: 1px solid var(--sl-color-hairline-light);
+    }
 
-  li {
-    overflow-wrap: anywhere;
-  }
+    li {
+      overflow-wrap: anywhere;
+    }
 
-  li + li {
-    margin-top: 0.25rem;
-  }
+    li + li {
+      margin-top: 0.25rem;
+    }
 
-  a {
-    align-items: center;
-    color: var(--sl-color-white);
-    display: flex;
-    font-size: var(--sl-text-base);
-    font-weight: 600;
-    gap: 0.5rem;
-    line-height: 1.5;
-    padding: 0.3em 0.5rem;
-    text-decoration: none;
-  }
+    a {
+      align-items: center;
+      color: var(--sl-color-white);
+      display: flex;
+      font-size: var(--sl-text-base);
+      font-weight: 600;
+      gap: 0.5rem;
+      line-height: 1.5;
+      padding: 0.3em 0.5rem;
+      text-decoration: none;
+    }
 
-  a:is(.starlight-sidebar-topics-current, :hover, :focus-visible) {
-    color: var(--sl-color-accent-high);
-  }
+    a:is(.starlight-sidebar-topics-current, :hover, :focus-visible) {
+      color: var(--sl-color-accent-high);
+    }
 
-  :global([data-theme='light']) a.starlight-sidebar-topics-current {
-    color: var(--sl-color-accent);
-  }
+    :global([data-theme='light']) a.starlight-sidebar-topics-current {
+      color: var(--sl-color-accent);
+    }
 
-  .starlight-sidebar-topics-icon {
-    align-items: center;
-    border-radius: 0.25rem;
-    border: 1px solid var(--sl-color-gray-4);
-    display: flex;
-    justify-content: center;
-    padding: 0.25rem;
-  }
+    .starlight-sidebar-topics-icon {
+      align-items: center;
+      border-radius: 0.25rem;
+      border: 1px solid var(--sl-color-gray-4);
+      display: flex;
+      justify-content: center;
+      padding: 0.25rem;
+    }
 
-  a:is(.starlight-sidebar-topics-current, :hover, :focus-visible) .starlight-sidebar-topics-icon {
-    background-color: var(--sl-color-text-accent);
-    border-color: var(--sl-color-text-accent);
-    color: var(--sl-color-text-invert);
-  }
+    a:is(.starlight-sidebar-topics-current, :hover, :focus-visible) .starlight-sidebar-topics-icon {
+      background-color: var(--sl-color-text-accent);
+      border-color: var(--sl-color-text-accent);
+      color: var(--sl-color-text-invert);
+    }
 
-  .starlight-sidebar-topics-badge {
-    margin-inline-start: 0.25em;
+    .starlight-sidebar-topics-badge {
+      margin-inline-start: 0.25em;
+    }
   }
 </style>

--- a/packages/starlight-sidebar-topics/tests/sidebar.test.ts
+++ b/packages/starlight-sidebar-topics/tests/sidebar.test.ts
@@ -26,6 +26,7 @@ test('uses topic sidebars', async ({ demoPage, docPage }) => {
     'Start Here',
     'Getting Started',
     'Configuration',
+    'Customization',
     'Guides',
     'Unlisted Pages',
     'Excluded Pages',


### PR DESCRIPTION
**Describe the pull request**

This PR wraps all CSS from the `starlight-sidebar-topics` plugin in a new `sidebar-topics` layer.

My bad, I saw the existing issue and your comment there after creating this PR.
If you have come up with a more creative solution to support CSS overrides in plugins rather than themes, feel free to close this 👍

Otherwise:
- Closes #47

**Why**

This allows to override sidebar topic styles more easily.
An example, where we hit a limitation is this issue: https://github.com/bombshell-dev/docs/issues/37

**How**

- All styles in `Topics.astro` were wrapped in a new `@layer sidebar-topics`.
- A new documentation page was added to inform people how to override the styles without having to use `!important`.
- The first commit introduces an example in the docs, which does not work because there are no cascade layers yet (this needs to be removed before merging!)

**Screenshots**

The example in the documentation can now be seen:

<img width="278" height="132" alt="image" src="https://github.com/user-attachments/assets/b3a7e1cf-4057-407b-8692-2a3638616e85" />

> [!NOTE]
> The custom styles which were used to demonstrate what is not working should be removed before merging. Feel free to commit this update yourself 👍 
