### PR TITLE
docs: fix grammar

### DIFF
--- a/docs/src/content/docs/docs/guides/excluded-pages.mdx
+++ b/docs/src/content/docs/docs/guides/excluded-pages.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-By default, the Starlight Sidebar Topics plugin expect that every pages in your project is associated with a topic.
+By default, the Starlight Sidebar Topics plugin expects that every page in your project is associated with a topic.
 This is done by including the page in a [topic sidebar configuration](/docs/configuration#items) or using the `topic` frontmatter field for [unlisted pages](/docs/guides/unlisted-pages/).
 
 However, there are cases where you may have [custom pages](https://starlight.astro.build/guides/pages/#custom-pages) that use a [custom site navigation sidebar](https://starlight.astro.build/guides/pages/#sidebar) which do not belong to any topic.

--- a/docs/src/content/docs/docs/guides/unlisted-pages.mdx
+++ b/docs/src/content/docs/docs/guides/unlisted-pages.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-By default, the Starlight Sidebar Topics plugin expect that every [content pages](https://starlight.astro.build/guides/pages/#content-pages) in your project is associated with a topic.
+By default, the Starlight Sidebar Topics plugin expects that every [content page](https://starlight.astro.build/guides/pages/#content-pages) in your project is associated with a topic.
 This is done by including the content page in a [topic sidebar configuration](/docs/configuration#items) and the plugin will automatically determine which sidebar to display based on the current page.
 
 However, there are cases where you may want to have a content page that is not listed in any topic sidebar while still displaying the sidebar of a specific topic or to associate custom pages generated and included in the sidebar by other plugins with a specific topic.


### PR DESCRIPTION
This PR fixes grammar issues in the documentation.

*BTW*: I find the fact that every page needs to be associated with a topic somehow limiting.

I'm trying to illustrate this with an example:
This is part of my sidebar definition:
```
starlightSidebarTopics([
{
	label: 'User documentation',
	link: '/guide/user/',
	icon: 'open-book',
	items: [
		{
			label: 'Foo',
			items: [{ autogenerate: { directory: 'guide/user' } }]},
	],
}
```

This works, but I want the topic link to be `/guide/` not `/guide/user/`
So I create `src/content/docs/guide/index.mdx` to achieve that, but now the project does not build any more since it fails to find the topic for the `guide` page. I want to be able to link to and to display the `/guide/` page without having an entry to the page in the sidebar. Is there any way to achieve that? Thanks for your help.